### PR TITLE
Revert "⬆️ Bump python from 3.11.5 to 3.12.0"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.0
+FROM python:3.11.5
 
 WORKDIR /api
 


### PR DESCRIPTION
Reverts Creaty-Co/creaty-api#465

Reason: https://creaty-co.sentry.io/share/issue/f190dec436ad427d9305cb30ebe9b90d/